### PR TITLE
Phase C: make validation cold-clone safe

### DIFF
--- a/reports/data_validation/ims_set1_phase_c_v1/validation_report.md
+++ b/reports/data_validation/ims_set1_phase_c_v1/validation_report.md
@@ -54,3 +54,49 @@ natural-key, cardinality, and foreign-key failures; output no-op and malformed-o
 rejection; and CLI failure for invalid config. The synthetic test uses no raw signals or
 tracked canonical output. This is focused contract coverage, not an exhaustive proof of
 all filesystem races or all possible corruptions of Phase B artifacts.
+
+## Cold-clone evidence verification correction
+
+The prior unit-test contract mixed pure outcome-config validation with verification of
+the developer-local metadata PDF. The PDF is intentionally not repository-tracked, so a
+clean checkout could not run ordinary config tests even though the publication contract
+was correct. The implementation now separates `_validate_config(config_path)`, which
+reads only the declarative configuration and validates its schema, scientific contract,
+safe relative path, and SHA-256 shape, from `_verify_metadata_evidence(repo_root, cfg)`.
+The latter retains the stable no-follow reader and mandatory byte-for-byte PDF pin before
+any Phase B load, row construction, output creation, or no-op acceptance.
+
+The committed publication evidence contract is unchanged: evidence ID
+`ims_metadata_pdf_set1_terminal_damage_v1`, path
+`data/Readme Document for IMS Bearing Data.pdf`, page 1, classification
+`publisher_metadata_terminal_damage_documented_by_experiment_end`, and SHA-256
+`cf46d37c21f7f292c11bbbdd4695d876c417ed1d6425e3d87c962ae2182ae6ed`.
+The PDF is neither claimed redistributable nor repository-tracked. Permanent tests use
+synthetic bytes under temporary directories for matching, missing, substituted,
+symlinked, and non-regular evidence cases. They also prove absent evidence stops the
+build before Phase B loading and preserves absent or existing outputs; the CLI fails
+nonzero without publication.
+
+In an isolated source snapshot without the PDF, the focused Phase C suite collected 31
+tests and the full DB-free suite collected 101 tests; both passed. A fresh Python 3.11.15
+PDF-free snapshot imported `src.data.set1_outcomes` from its own corrected source tree,
+then passed the base Ruff command and verbose 101-test pytest command using the already
+proven dependency environment. A separate focused run also passed with a synthetic file
+present at the configured evidence path; the guarded reader test proved pure config
+validation did not open that file.
+
+Final publication-time evidence used the hotfix source worktree as the child current
+working directory and recorded its resolved module path and source SHA-256
+`e56e0a1aae7334baf083d8e962357e61205fd04b4f21b978327c83482efeada7`.
+Against the original local repository root where the pinned PDF exists, that monitored
+producer invocation returned zero with empty stderr and `published: false`. It preserved
+the canonical directory/member device, inode, mode, size, nanosecond mtime, bytes,
+hashes, and member set. The earlier monitored no-op is retained as historical support but
+was not used as final source-origin proof because it did not record child cwd/module
+origin. Temporary review evidence is at
+`/private/tmp/ims_set1_phase_c_ci_hotfix_final_noop_v2.ukFsXd`,
+`/private/tmp/ims_set1_phase_c_ci_snapshot_corrected.CznQuB`, and
+`/private/tmp/ims_set1_phase_c_ci_evidence_present.HP3bdT`.
+
+No outcome/proxy science, configuration values, canonical artifact hashes, or decision
+record changed in this correction.

--- a/src/data/set1_outcomes.py
+++ b/src/data/set1_outcomes.py
@@ -204,16 +204,17 @@ def _check_phase_b(repo: Path, cfg: dict[str, Any]) -> tuple[list[dict[str, Any]
     return bearing, sensor, trajectories
 
 
-def _validate_config(repo: Path, config_path: Path) -> dict[str, Any]:
+def _validate_config(config_path: Path) -> dict[str, Any]:
+    """Validate the declarative Phase C contract without opening repository inputs."""
     cfg = _object(_json(config_path, "outcome config"), CONFIG_FIELDS, "outcome config")
     if cfg["schema_version"] != "ims_set1_outcomes_v1" or not isinstance(cfg["outcomes"], list) or len(cfg["outcomes"]) != 4:
         raise OutcomeError("invalid outcome config identity or outcome count")
     _sha(cfg["phase_a_manifest_sha256"], "phase_a_manifest_sha256")
     evidence = _object(cfg["metadata_evidence"], {"evidence_id", "relative_path", "sha256", "page", "classification"}, "metadata_evidence")
-    if not all(isinstance(evidence[name], str) and evidence[name] for name in ("evidence_id", "classification")) or not isinstance(evidence["page"], int) or evidence["page"] < 1:
+    if not all(isinstance(evidence[name], str) and evidence[name] for name in ("evidence_id", "classification")) or type(evidence["page"]) is not int or evidence["page"] < 1:
         raise OutcomeError("invalid metadata evidence")
-    if sha256_bytes(_stable_bytes(repo / _relative(evidence["relative_path"], "metadata_evidence.relative_path"), "metadata evidence")) != _sha(evidence["sha256"], "metadata evidence sha256"):
-        raise OutcomeError("metadata evidence pin mismatch")
+    _relative(evidence["relative_path"], "metadata_evidence.relative_path")
+    _sha(evidence["sha256"], "metadata evidence sha256")
     contract = _object(cfg["proxy_contract"], {"proxy_contract_id", "first_proxy_seconds", "interpretation"}, "proxy_contract")
     if (
         contract["proxy_contract_id"] != "ims_set1_observed_run_endpoint_proxy_v1"
@@ -243,6 +244,20 @@ def _validate_config(repo: Path, config_path: Path) -> dict[str, Any]:
         if observed != expected:
             raise OutcomeError(f"invalid scientific outcome claim for {bearing}")
     return cfg
+
+
+def _verify_metadata_evidence(repo_root: Path, cfg: dict[str, Any]) -> None:
+    """Fail closed unless the configured metadata evidence is the pinned file snapshot."""
+    evidence = cfg["metadata_evidence"]
+    if not isinstance(evidence, dict):
+        raise OutcomeError("invalid metadata evidence")
+    relative_path = _relative(evidence.get("relative_path"), "metadata_evidence.relative_path")
+    expected_hash = _sha(evidence.get("sha256"), "metadata evidence sha256")
+    actual_hash = sha256_bytes(
+        _stable_bytes(repo_root / relative_path, "metadata evidence")
+    )
+    if actual_hash != expected_hash:
+        raise OutcomeError("metadata evidence pin mismatch")
 
 
 def _publish(output: Path, artifacts: dict[str, bytes]) -> bool:
@@ -343,7 +358,8 @@ def _build_outcome_rows(
 
 
 def build_outcomes(config_path: Path, repo_root: Path, output: Path) -> tuple[bool, dict[str, str]]:
-    cfg = _validate_config(repo_root, config_path)
+    cfg = _validate_config(config_path)
+    _verify_metadata_evidence(repo_root, cfg)
     bearing, _sensor, trajectories = _check_phase_b(repo_root, cfg)
     outcomes, proxies = _build_outcome_rows(cfg, bearing, trajectories, expected_proxy_count=8624)
     artifacts = {

--- a/tests/unit/test_set1_outcomes.py
+++ b/tests/unit/test_set1_outcomes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import os
 from datetime import datetime, timedelta
@@ -10,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+import src.data.set1_outcomes as outcomes_module
 from src.data.set1_outcomes import (
     OUTPUTS,
     OutcomeError,
@@ -18,12 +20,21 @@ from src.data.set1_outcomes import (
     _publish,
     _validate_config,
     _validate_phase_b_relations,
+    _verify_metadata_evidence,
+    build_outcomes,
     main,
 )
 
 
 REPO = Path(__file__).resolve().parents[2]
 CONFIG = REPO / "configs/datasets/ims_set1_outcomes_v1.json"
+COMMITTED_METADATA_EVIDENCE = {
+    "evidence_id": "ims_metadata_pdf_set1_terminal_damage_v1",
+    "relative_path": "data/Readme Document for IMS Bearing Data.pdf",
+    "sha256": "cf46d37c21f7f292c11bbbdd4695d876c417ed1d6425e3d87c962ae2182ae6ed",
+    "page": 1,
+    "classification": "publisher_metadata_terminal_damage_documented_by_experiment_end",
+}
 
 
 @pytest.fixture
@@ -35,6 +46,18 @@ def _write_config(tmp_path: Path, value: dict[str, object]) -> Path:
     path = tmp_path / "outcomes.json"
     path.write_text(json.dumps(value), encoding="utf-8")
     return path
+
+
+def _synthetic_evidence_config(
+    config: dict[str, object], relative_path: str, content: bytes,
+) -> dict[str, object]:
+    changed = copy.deepcopy(config)
+    changed["metadata_evidence"] = {
+        **changed["metadata_evidence"],
+        "relative_path": relative_path,
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+    return changed
 
 
 def _synthetic_graph() -> tuple[list[dict[str, object]], list[dict[str, object]], list[dict[str, object]]]:
@@ -70,8 +93,19 @@ def _synthetic_graph() -> tuple[list[dict[str, object]], list[dict[str, object]]
     return bearing_rows, sensor_rows, trajectories
 
 
-def test_config_is_exact_committed_contract(config: dict[str, object]) -> None:
-    _validate_config(REPO, CONFIG)
+def test_config_is_exact_committed_contract(
+    config: dict[str, object], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_stable_bytes = outcomes_module._stable_bytes
+
+    def config_only_reader(path: Path, label: str) -> bytes:
+        if path.resolve() != CONFIG.resolve():
+            raise AssertionError(f"pure config validation accessed non-config path: {path}")
+        return original_stable_bytes(path, label)
+
+    monkeypatch.setattr(outcomes_module, "_stable_bytes", config_only_reader)
+    assert _validate_config(CONFIG) == config
+    assert config["metadata_evidence"] == COMMITTED_METADATA_EVIDENCE
     assert config["proxy_contract"] == {
         "proxy_contract_id": "ims_set1_observed_run_endpoint_proxy_v1",
         "first_proxy_seconds": 2_979_212,
@@ -100,7 +134,91 @@ def test_config_rejects_schema_and_scientific_claim_drift(
     changed = copy.deepcopy(config)
     mutate(changed)
     with pytest.raises(OutcomeError, match=message):
-        _validate_config(REPO, _write_config(tmp_path, changed))
+        _validate_config(_write_config(tmp_path, changed))
+
+
+@pytest.mark.parametrize("relative_path", ("/absolute.pdf", "../escape.pdf", "data\\evidence.pdf"))
+def test_config_rejects_unsafe_metadata_evidence_paths(
+    tmp_path: Path, config: dict[str, object], relative_path: str,
+) -> None:
+    changed = copy.deepcopy(config)
+    changed["metadata_evidence"]["relative_path"] = relative_path
+    with pytest.raises(OutcomeError, match="unsafe|invalid metadata_evidence.relative_path"):
+        _validate_config(_write_config(tmp_path, changed))
+
+
+def test_metadata_evidence_verification_accepts_matching_synthetic_bytes(
+    tmp_path: Path, config: dict[str, object],
+) -> None:
+    content = b"synthetic terminal damage evidence\n"
+    path = tmp_path / "data/evidence.pdf"
+    path.parent.mkdir()
+    path.write_bytes(content)
+    _verify_metadata_evidence(
+        tmp_path, _synthetic_evidence_config(config, "data/evidence.pdf", content),
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "message"),
+    (
+        ("missing", "cannot open metadata evidence"),
+        ("wrong_bytes", "metadata evidence pin mismatch"),
+        ("symlink", "metadata evidence is not a regular file"),
+        ("non_regular", "metadata evidence is not a regular file"),
+    ),
+)
+def test_metadata_evidence_verification_rejects_invalid_source(
+    tmp_path: Path, config: dict[str, object], kind: str, message: str,
+) -> None:
+    content = b"expected evidence\n"
+    path = tmp_path / "data/evidence.pdf"
+    path.parent.mkdir()
+    if kind == "wrong_bytes":
+        path.write_bytes(b"substituted evidence\n")
+    elif kind == "symlink":
+        target = tmp_path / "target.pdf"
+        target.write_bytes(content)
+        path.symlink_to(target)
+    elif kind == "non_regular":
+        os.mkfifo(path)
+    with pytest.raises(OutcomeError, match=message):
+        _verify_metadata_evidence(
+            tmp_path, _synthetic_evidence_config(config, "data/evidence.pdf", content),
+        )
+
+
+def test_missing_evidence_stops_build_before_phase_b_or_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "outcomes"
+
+    def unexpected_phase_b(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("Phase B loading must not run without metadata evidence")
+
+    monkeypatch.setattr(outcomes_module, "_check_phase_b", unexpected_phase_b)
+    with pytest.raises(OutcomeError, match="cannot open metadata evidence"):
+        build_outcomes(CONFIG, tmp_path, output)
+    assert not output.exists()
+
+
+def test_missing_evidence_preserves_existing_output_and_cli_fails(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "outcomes"
+    output.mkdir()
+    marker = output / "unchanged"
+    marker.write_bytes(b"preserve me")
+    before = (marker.read_bytes(), marker.stat().st_ino, marker.stat().st_mtime_ns)
+    with pytest.raises(OutcomeError, match="cannot open metadata evidence"):
+        build_outcomes(CONFIG, tmp_path, output)
+    assert (marker.read_bytes(), marker.stat().st_ino, marker.stat().st_mtime_ns) == before
+
+    cli_output = tmp_path / "cli-outcomes"
+    assert main([
+        "--repo-root", str(tmp_path), "--config", str(CONFIG), "--output-dir", str(cli_output),
+    ]) == 2
+    assert not cli_output.exists()
 
 
 def test_known_answer_terminal_outcome_id_is_stable() -> None:


### PR DESCRIPTION
## Scope
- Separates pure Phase C configuration validation from mandatory metadata-evidence verification.
- Keeps the pinned PDF check fail-closed for every build, publication, and no-op path.
- Adds synthetic evidence tests so ordinary unit tests do not require a developer-local PDF.

## Verification
- 31 focused Phase C tests and 101 DB-free tests passed.
- PDF-free Python 3.11 source-snapshot verification passed.
- A monitored no-op with the pinned local evidence preserved all Phase C canonical bytes and metadata.

No outcome/proxy science, configuration values, canonical artifacts, Phase D files, or unrelated local state are included.