### PR TITLE
Phase L: freeze condition-monitoring direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,15 +5,18 @@ evidence of model performance.
 
 ## Project status and evidence boundary
 
-This repository is a corrective ML validation project for bearing remaining useful
-life (RUL) prediction using the NASA IMS dataset. It is **not production-ready**.
+This repository is a corrective evidence and condition-monitoring project using the
+NASA IMS dataset. Its primary product objective is causal condition-deviation
+monitoring with persistent human-review inspection alerts, not automatic bearing
+replacement or a claim of exact RUL. It is **not production-ready**.
 
 The existing tuned LightGBM artifact, Streamlit dashboard, and FastAPI endpoint are
 historical prototypes. Their old headline metrics came from row-level RUL-bin
 stratification and pre-split preprocessing; they are not valid evidence of unseen
 bearing or production generalization.
 
-Leakage-safe Phase 1 is the performance source of truth:
+Leakage-safe Phase 1 is historical evidence of why row-level RUL claims are not
+usable as the active direction:
 
 | Strategy | MAE | Interpretation |
 | --- | ---: | --- |
@@ -29,6 +32,9 @@ trajectories makes all current generalization evidence statistically thin.
 
 Read before making ML, evaluation, documentation, or Set 2 changes:
 
+- `docs/PROJECT_ROADMAP.md`;
+- `docs/CONDITION_MONITORING_ARCHITECTURE.md`;
+- `docs/decisions/DECISIONS.md` D-043;
 - `docs/decisions/DECISIONS.md` D-021 through D-028;
 - `reports/evaluation/phase1_validation_leakage_safe/validation_report.md`;
 - `docs/EVALUATION_POLICY.md`;
@@ -37,25 +43,28 @@ Read before making ML, evaluation, documentation, or Set 2 changes:
 - `docs/decisions/DECISIONS.md` D-035 through D-036 and
   `reports/evaluation/ims_set1_phase_e_identifiability_v1/validation_report.md`.
 
-Do not make production, broad generalization, or maintenance-savings claims from the
-historical artifact or from Set 1 alone. Do not select a model using a row-level split.
+Do not make production, broad generalization, guaranteed maintenance-savings, or exact
+maintenance-timing claims from the historical artifact or from Set 1 alone. Do not
+select a model using a row-level split.
 
 ## Evaluation rules
 
-`src/models/offline_validation.py` is the DB-free, artifact-preserving validation path.
-It compares the historical row-level baseline with LOBO and purged time-series CV and
-performs fold-local preprocessing in leakage-safe mode. Its reports, rather than the
-legacy database evaluation scripts, are the current evaluation authority.
+`src/models/offline_validation.py` is a DB-free, artifact-preserving historical
+validation path. Its reports establish leakage and endpoint-proxy limitations; they
+do not define the next product. The active evaluation contract is in
+`docs/EVALUATION_POLICY.md` and D-043.
 
 - Treat the `src/data/split_stratified.py` output as a historical/leaky baseline only.
   It uses `train_test_split` over feature rows stratified by RUL bin and does not prove
   temporal or unseen-bearing generalization.
-- Follow `docs/EVALUATION_POLICY.md` for any separately authorized retuning: LOBO
-  business-risk score is primary; purged time-series CV is a required secondary guard.
-- Fit feature selection, normalization, imputation, and temporal transforms on training
-  data only within each fold. Preserve prior reports and write new outputs separately.
-- The current critical (RUL <= 50h) and warning (RUL <= 100h) thresholds are provisional
-  project conventions, not business-approved operating thresholds.
+- Any separately authorized monitor must group physical trajectories, evaluate
+  chronologically or with a purge, and fit preprocessing within each fold. Preserve
+  prior reports and write new outputs separately.
+- Elapsed-time-only and fixed-interval policies are mandatory baselines. A signal
+  monitor must outperform them under trajectory-safe evaluation before claiming
+  condition-monitoring value; learning experiment age alone is not enough.
+- Endpoint proximity is retrospective evaluation only. It cannot fit monitor features,
+  thresholds, or online scoring, and it is not failure lead time.
 - Phase E established that the observed-run-end proxy is exactly reproduced by the shared
   experiment clock for Set 1. Do not retune, rank, or promote a model against that proxy
   as bearing-degradation evidence. The fixed Phase E Ridge diagnostic is not a GO signal.
@@ -112,9 +121,10 @@ outcome, feature, evaluation, model, pooling, adaptation, or serving work.
   pooling still requires a separately authorized ADR.
 
 The permitted pre-consumption checks and the point at which Set 2 becomes consumed are
-defined in `docs/SET2_INTAKE_DESIGN.md` and D-027. Documentation approval is not
-implementation authorization. See `docs/SET3_INTAKE_DESIGN.md` and D-037 for the
-parallel Set 3 source boundary.
+defined in `docs/SET2_INTAKE_DESIGN.md` and D-027. Phase G structural processing does
+not authorize outcome, feature, model, or evaluation work. Documentation approval is
+not implementation authorization. See `docs/SET3_INTAKE_DESIGN.md` and D-037 for the
+parallel source boundary.
 
 ## Environment and tests
 
@@ -166,7 +176,9 @@ promote, deploy, or change them as if they represented a validated model.
 ## Change discipline
 
 - Preserve historical reports and clearly label historical/leaky outputs.
-- Keep Set 1 failure/censoring semantics explicit: 3/4 failed; 1/2 censored.
+- Keep Set 1 terminal-evidence semantics explicit: bearings 3 and 4 have documented
+  terminal damage; bearings 1 and 2 have no documented terminal damage before
+  observation end and are not event-free, healthy, or censored labels.
 - Do not pool Set 2 or make Set 2 implementation changes without the documented gates
   and separate authorization.
 - Do not bypass leakage-safe validation to improve headline metrics.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # IMS Bearing Failure Prediction
 
-Corrective ML validation project for remaining useful life (RUL) prediction on
-the NASA IMS bearing dataset.
+Corrective evidence and condition-monitoring project for the NASA IMS bearing
+dataset.
 
 This repository is **not production-ready** today. Earlier documentation claimed
 production-grade performance from a row-level stratified split, but Phase 1
 validation showed that those metrics were inflated by temporal train/test leakage
-and preprocessing leakage. The current purpose of the project is to make the ML
-methodology honest and reproducible before any API, dashboard, cloud, or MLOps
-productionization work.
+and preprocessing leakage. The current purpose is to establish causal
+condition-deviation monitoring with human-review inspection alerts before any API,
+dashboard, cloud, or productionization work.
 
 ---
 
@@ -16,11 +16,11 @@ productionization work.
 
 | Area | Status |
 | --- | --- |
-| ML objective | Diagnose whether Set 1 endpoint-proxy regression contains bearing-specific signal beyond the shared run clock |
-| Current diagnostic | Fixed sensor-local Ridge diagnostic and explicit shared-run clock reference |
-| Current evidence level | Offline validation and canonical artifact evidence only |
+| Primary objective | Causal condition-deviation monitoring with persistent human-review inspection alerts |
+| Endpoint-proxy boundary | `observed_failure_endpoint_proxy` is a secondary retrospective convention, not exact failure or RUL truth |
+| Current evidence level | Canonical artifacts and governance evidence only; no condition monitor is implemented yet |
 | Production readiness | Not production-ready |
-| Source-of-truth report | `reports/evaluation/phase1_validation_leakage_safe/validation_report.md` |
+| Current direction | `docs/PROJECT_ROADMAP.md`, `docs/CONDITION_MONITORING_ARCHITECTURE.md`, and D-043 |
 
 The old headline metrics, including `2.88h` critical-zone MAE, `13.42h` overall
 MAE, and `R2 = 0.9852`, should be treated as **deprecated leaky-baseline results**.
@@ -28,7 +28,7 @@ They are not valid production evidence.
 
 ---
 
-## Leakage-Safe Phase 1 Results
+## Historical Leakage-Safe Phase 1 Results
 
 The leakage-safe validation reran the same selected feature set with fold-local
 preprocessing:
@@ -101,11 +101,22 @@ the frozen identities, folds, targets, zero-second clock oracle, conclusion, and
 discretes, but cannot claim canonical Ridge bytes.
 
 Bearings 3 and 4 are the only documented damaged trajectories and are used for LOBO.
-Bearings 1 and 2 are inference-only censored/undocumented-outcome clock-tracking and
-alert-burden observations, not healthy controls or accuracy labels. See
+Bearings 1 and 2 are inference-only clock-tracking and alert-burden observations with
+no documented terminal damage before observation end, not healthy controls, censored
+labels, or accuracy labels. See
 `reports/evaluation/ims_set1_phase_e_identifiability_v1/validation_report.md`.
 
 ---
+
+## Active Documentation Map
+
+- `docs/PROJECT_ROADMAP.md`: current phase sequence and evidence gates.
+- `docs/CONDITION_MONITORING_ARCHITECTURE.md`: current condition-monitoring and
+  policy-comparison contract.
+- `docs/decisions/DECISIONS.md` D-043: frozen direction and explicit boundaries.
+- `docs/EVALUATION_POLICY.md`: current trajectory-safe evaluation policy.
+- `docs/PRODUCTION_READINESS.md`, `docs/DESIGN_REVIEW.md`, and historical reports:
+  retained snapshots, not current implementation direction.
 
 ## Repository Map
 
@@ -166,14 +177,16 @@ ruff check .
 
 ---
 
-## Recommended Next Steps
+## Current Path
 
-1. Obtain an independently governed target with bearing-specific outcome timing before
-   retuning or interpreting endpoint-proxy metrics as degradation evidence.
-2. Keep Set 2 in its frozen development-evidence role. Do not perform outcome/event-time work
-   or development use without separate authorization; pooling requires a separate ADR.
-3. Do not revisit API/dashboard productionization until an independently valid target
-   and cross-trajectory evidence exist.
+1. Complete the documentation contract in Phase L, then separately authorize Phase M
+   causal condition-monitor implementation.
+2. Compare condition-monitor behavior to run-to-failure, fixed-interval, and
+   elapsed-time-only policies before interpreting signal value.
+3. Keep Set 2 in its frozen development-evidence role. Do not perform outcome/event-time
+   work or development use without separate authorization; pooling requires a separate ADR.
+4. Do not revisit API/dashboard productionization until later evidence supports a
+   human-review workflow and prospective validation.
 
 ---
 

--- a/docs/CONDITION_MONITORING_ARCHITECTURE.md
+++ b/docs/CONDITION_MONITORING_ARCHITECTURE.md
@@ -1,0 +1,98 @@
+# Condition Monitoring Architecture
+
+This is the active architecture for the next authorized implementation phase. It
+separates existing evidence foundations from the planned condition monitor. No
+monitor, alert, replacement policy, or serving path is implemented by this document.
+
+## Product Contract
+
+The monitor will identify persistent causal deviation from an early-trajectory
+baseline and emit an inspection alert for human review. It does not label a bearing
+healthy, failed, or due for automatic replacement.
+
+```mermaid
+flowchart LR
+    A["Raw source"] --> B["Manifest, identity, and outcome evidence"]
+    B --> C["Causal sensor-local features"]
+    C --> D["Early-prefix baseline and reference behavior"]
+    D --> E["Causal deviation score"]
+    E --> F["Physical-bearing sensor aggregation"]
+    F --> G["Causal change detector"]
+    G --> H["Persistence and hysteresis"]
+    H --> I["Deviation regime"]
+    I --> J["Human review"]
+    J --> K["Maintenance action"]
+    K --> L["Outcome feedback"]
+    F --> M["Trajectory-safe evaluation and policy comparison"]
+    M --> N["Scenario-cost evidence"]
+```
+
+The manifest/identity/outcome evidence and canonical sensor-local features are
+implemented foundations. The early-prefix baseline through outcome feedback are
+planned components. Evaluation and scenario-cost work remain planned and cannot
+claim a field result.
+
+## Planned Causal Monitor Contract
+
+For each monitored physical trajectory, the future Phase M implementation must:
+
+1. Fit a robust sensor-local baseline and nearest-neighbor/reference behavior from
+   only an early prefix of that trajectory.
+2. Score later timestamps causally, without future information or full-trajectory
+   normalization.
+3. Aggregate the two sensor views at the physical-bearing timestamp using fixed,
+   documented weights.
+4. Apply a causal change detector and persistence/hysteresis rule.
+5. Emit exactly one of these scientific states:
+   `baseline-consistent`, `deviation-observed`,
+   `persistent-severe-deviation`, or `insufficient-evidence`.
+
+These are deviation regimes. They are not healthy, warning, failure, maintenance,
+or RUL truth. Endpoint proximity may be joined only after scoring for retrospective
+evaluation; it cannot fit features or thresholds and cannot enter online scoring.
+
+Before implementation, Phase M must predeclare a small sensitivity grid for baseline
+prefix length, reference-neighbor count, deviation threshold, persistence, and sensor
+weighting. It may not tune against a final endpoint proxy or use model selection to
+search this grid opportunistically.
+
+## Evaluation and Policy Contract
+
+The primary evidence will be baseline stability, descriptive trendability and
+monotonicity, cross-bearing consistency, alert burden, persistence/hysteresis,
+lead time to the observed endpoint, abstention, and sensitivity. Alert burden is not
+a false-positive rate without defensible state truth. Lead time is not failure lead
+time. Accuracy, AUC, and F1 are not claims without supported labels.
+
+Phase N will compare five policies:
+
+1. Run to failure.
+2. Fixed-interval replacement.
+3. Elapsed-time-only policy.
+4. Endpoint-proxy supervised benchmark.
+5. Signal-based condition monitor.
+
+The scenario calculation must keep each client-supplied input visible:
+
+```text
+total cost = unplanned failures * failure/downtime cost
+           + planned replacements * replacement cost
+           + premature-life loss cost
+           + inspections * inspection cost
+```
+
+Required inputs are failure/downtime cost, planned replacement cost, inspection
+cost, intervention lead time, lost remaining-life cost, and operating
+horizon/population. The decision ladder is `monitor -> inspect -> schedule
+maintenance -> urgent action`. Until prospective client evidence exists, results are
+ranges and sensitivities, not guaranteed savings, production effectiveness, exact
+failure timing, or automatic-replacement readiness.
+
+## Data and Evidence Boundary
+
+Set 1 is development evidence. The `observed_failure_endpoint_proxy` convention
+applies only where the official manual identifies terminal damage and remains a
+secondary retrospective benchmark. Set 2 has a frozen role under Phase I and no
+supervised target under Phases J and K; this architecture authorizes neither use nor
+target creation. The observed candidate remains protected until source/identity
+resolution. No external-generalization claim is supported today.

--- a/docs/DESIGN_REVIEW.md
+++ b/docs/DESIGN_REVIEW.md
@@ -1,5 +1,10 @@
 # Design Review — Response to Principal-Engineer Peer Review
 
+> **Historical snapshot:** This 2026-07-04 review is retained as context, not active
+> project direction. Use `docs/PROJECT_ROADMAP.md`,
+> `docs/CONDITION_MONITORING_ARCHITECTURE.md`, and D-043 for current guidance. It does
+> not authorize RUL-first work, model deployment, or production claims.
+
 **Date:** 2026-07-04
 **Branch:** `production-readiness-refactor` (nothing merged/pushed to `main`)
 **Author stance:** independent technical evaluation. Where I disagree with the

--- a/docs/EVALUATION_POLICY.md
+++ b/docs/EVALUATION_POLICY.md
@@ -1,17 +1,28 @@
-# Business-Aligned Evaluation Policy
+# Condition Monitoring and Policy Evaluation
 
-This document defines the evaluation objective future retuning must follow. It
-supersedes any model-selection process that optimizes only generic MAE or R2.
+This document defines the active evaluation objective. Causal condition-deviation
+monitoring with persistent human-review inspection alerts is primary. Historical
+endpoint-proxy regression is secondary retrospective context, not the current
+product objective.
 
 Source-of-truth baseline for this policy:
 `reports/evaluation/phase1_validation_leakage_safe/validation_report.md`.
 
-**Label boundary:** Historical "RUL" metrics evaluate the observed-run-end proxy used
-by the legacy pipeline, not exact physical RUL truth or exact failure-time accuracy.
-They must be described as endpoint-proxy metrics unless separately supported event-time
-evidence is introduced.
+**Evidence boundary:** For a trajectory whose official IMS manual identifies terminal
+damage, the final observation timestamp may be used only as the documented
+`observed_failure_endpoint_proxy` convention. It is not exact failure onset, a
+last-good/first-bad record, functional-failure threshold, or field maintenance truth.
+Phase E showed that the Set 1 observed-run-end proxy is exactly reproducible from the
+shared experiment clock; experiment age alone is not condition sensitivity.
 
-## Current Evidence
+The next separately authorized monitor must use an early-prefix sensor-local baseline,
+causal scoring, physical-bearing aggregation, a causal change detector, and
+persistence/hysteresis. It may emit only `baseline-consistent`,
+`deviation-observed`, `persistent-severe-deviation`, or `insufficient-evidence`.
+Those are deviation regimes, not healthy, warning, failure, maintenance, or RUL truth.
+Endpoint proximity may be joined only after scoring for retrospective evaluation.
+
+## Historical Endpoint-Proxy Evidence
 
 Leakage-safe Phase 1 metrics:
 
@@ -24,7 +35,7 @@ Leakage-safe Phase 1 metrics:
 The row-level baseline is diagnostic only. It must not be used to select or
 promote a model because it has same-bearing timestamp contamination.
 
-## Deployment Questions
+## Historical Endpoint-Proxy Questions
 
 The project has two distinct predictive-maintenance questions:
 
@@ -33,14 +44,10 @@ The project has two distinct predictive-maintenance questions:
 | Can the model generalize to a failed bearing not seen during training? | Leave-One-Bearing-Out (LOBO) | Primary |
 | Can the model monitor a known bearing over time without adjacent-row leakage? | Purged time-series CV | Required secondary |
 
-Primary tuning objective: **LOBO business-risk score**.
+This historical policy does not authorize RUL-first retuning or model promotion. The
+old row-level baseline remains only a leakage-inflation comparison.
 
-Purged time-series CV is a required secondary check. A model may not be promoted
-if it improves LOBO while catastrophically degrading purged-CV warning behavior.
-
-The old row-level baseline remains only a leakage-inflation comparison.
-
-## Threshold Policy
+## Historical Threshold Policy
 
 Current thresholds:
 
@@ -55,7 +62,7 @@ agreement, repair lead time, or subject-matter-expert sign-off**. Retuning must
 therefore report sensitivity at both thresholds and label them provisional until
 business data justifies them.
 
-## Required Metrics
+## Historical Endpoint-Proxy Metrics
 
 Every future tuning run must report these metrics for LOBO and purged time-series
 CV:
@@ -75,7 +82,7 @@ CV:
 | Sample counts and RUL distribution | Counts by split/fold/RUL bin | Guards against empty or unrepresentative folds |
 | Split contamination checks | Exact key overlap and same-bearing timestamp overlap | Validates leakage-free evaluation |
 
-## Scalar Objective For Automated Tuning
+## Historical Scalar Objective
 
 If Optuna or another tuner requires one scalar objective, use this provisional
 LOBO score:
@@ -104,21 +111,24 @@ This scalar score is provisional. Replace the weights once actual downtime cost,
 maintenance dispatch cost, bearing replacement cost, and required lead time are
 known.
 
-## Model Selection Rules
+## Current Selection Rules
 
-Future retuning must follow these rules:
+Any separately authorized monitor or benchmark must follow these rules:
 
-1. Optimize on leakage-safe LOBO business-risk score.
-2. Report purged time-series CV as a required secondary result.
-3. Report both mean and worst-fold values.
-4. Do not select a model using the row-level baseline.
-5. Do not promote a model that has train/test key overlap or same-bearing
-   timestamp overlap in LOBO or purged validation.
-6. Do not claim production readiness from Set 1 alone.
-7. Treat improvements as provisional until Set 2/3 add more independent failure
-   trajectories.
+1. Group by physical trajectory and use chronological or purged evaluation with
+   fold-local preprocessing.
+2. Treat elapsed-time-only and fixed-interval policies as mandatory baselines. A
+   signal monitor must outperform them before claiming condition-monitoring value.
+3. Report baseline stability, descriptive trendability/monotonicity, cross-bearing
+   consistency, alert burden, persistence/hysteresis, lead time to the observed
+   endpoint, abstention, and sensitivity.
+4. Do not call alert burden a false-positive rate, or observed-endpoint lead time a
+   failure lead time, without defensible state truth.
+5. Do not select a model using row-level baselines or data with same-bearing
+   timestamp overlap.
+6. Do not claim production readiness or generalization from Set 1 alone.
 
-## Lead-Time Proxy
+## Historical Lead-Time Proxy
 
 A lead-time proxy is feasible from current time-ordered RUL labels, but it is not
 yet present in the Phase 1 CSV outputs.
@@ -134,25 +144,34 @@ Future tuning reports should add per-bearing lead-time metrics:
 These are proxies, not business-validated lead-time metrics, until maintenance
 planning lead time is provided.
 
-## Business Interpretation
+## Current Policy and Business Boundary
 
-For predictive maintenance, a missed critical warning is usually more expensive
-than a false alarm because it can allow unplanned downtime, secondary damage, or
-safety risk. A false alarm still has real cost: unnecessary inspection, premature
-replacement, alert fatigue, and loss of operator trust.
+Later policy work must compare run to failure, fixed-interval replacement,
+elapsed-time-only, endpoint-proxy supervised benchmark, and signal-based condition
+monitor. Its scenario inputs must be explicit:
 
-Until a real cost matrix exists, this project should favor catching critical
-near-failure samples over minimizing false alarms, but it must report both. A
-model that catches failures only by flagging everything as critical is not useful.
+```text
+total cost = unplanned failures * failure/downtime cost
+           + planned replacements * replacement cost
+           + premature-life loss cost
+           + inspections * inspection cost
+```
+
+Client-supplied inputs are failure/downtime cost, planned replacement cost,
+inspection cost, intervention lead time, lost remaining-life cost, and operating
+horizon/population. The decision ladder is `monitor -> inspect -> schedule
+maintenance -> urgent action`. State persistence, hysteresis, abstention, and the
+human inspection gate protect against premature replacement. Until prospective client
+evidence exists, report ranges and sensitivity, not guaranteed savings, production
+effectiveness, exact failure timing, or automatic-replacement readiness.
 
 ## Current Technical Priority
 
-Do not productionize the API/dashboard or retune against the observed-run-end proxy
-yet. Phase E established that this Set 1 target is exactly recoverable from the shared
-experiment clock, so it cannot distinguish bearing degradation from run position. The
-next technical priority is an independently governed target with bearing-specific outcome
-timing or a separately authorized external-validation design. Set 2 remains
-external-before-pooling and is not automatically authorized by any Phase E metric.
+Do not productionize the API/dashboard or retune against the observed-run-end proxy.
+Phase L freezes the condition-monitoring contract before the separately authorized
+Phase M implementation. Set 2 retains its frozen Phase I role and has no current use
+authorization; Phases J and K prohibit supervised target creation from current metadata.
+The observed candidate remains protected until source/identity resolution.
 
 Phase E's recorded canonical-publication runtime owns its exact diagnostic bytes. A
 portability-validation runtime may validate frozen identities, folds, endpoint-proxy

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -1,5 +1,10 @@
 # Production Readiness Audit & Refactor Blueprint
 
+> **Historical snapshot:** This audit records a 2026-07-04 review and is not the active
+> project direction. Use `docs/PROJECT_ROADMAP.md`,
+> `docs/CONDITION_MONITORING_ARCHITECTURE.md`, and D-043 for current guidance. The audit
+> does not authorize production work, RUL-first retuning, or a claim of readiness.
+
 **Repository:** `ims-bearing-failure-prediction`
 **Reviewed:** 2026-07-04
 **Reviewer role:** Staff ML Platform / MLOps / hiring-committee read

--- a/docs/PROJECT_ROADMAP.md
+++ b/docs/PROJECT_ROADMAP.md
@@ -1,0 +1,76 @@
+# Project Roadmap
+
+This is the active roadmap for the repository. It freezes the direction before
+any new modeling work. Historical reports, audits, and prototype code remain
+available as evidence, but they do not override this document, the condition
+monitoring architecture, or D-043.
+
+## Current Direction
+
+The primary product objective is causal condition-deviation monitoring that emits
+persistent inspection alerts for human review. It can support a maintenance
+decision; it cannot automatically command bearing replacement.
+
+For a trajectory whose official IMS manual identifies terminal damage, the final
+observation timestamp may be used only as the documented modeling convention
+`observed_failure_endpoint_proxy`. It supports secondary retrospective benchmarks
+for time to the observed endpoint. It is not exact failure onset, a last-good or
+first-bad timestamp, a functional-failure threshold, or field maintenance truth.
+
+Set 1 is development evidence. Set 2 retains its frozen Phase I role and is not
+authorized for use in this phase; later external validation requires separate
+authorization and the existing governance gates. The observed candidate can become
+external evidence only after source and identity resolution. No current artifact
+proves generalization, production readiness, maintenance savings, or exact
+maintenance timing.
+
+## Active Documentation Map
+
+| Document | Authority |
+| --- | --- |
+| This roadmap | Current sequence, scope, and phase gates |
+| `docs/CONDITION_MONITORING_ARCHITECTURE.md` | Current product and technical contract |
+| `docs/decisions/DECISIONS.md` D-043 | Frozen direction and evidence boundary |
+| `docs/EVALUATION_POLICY.md` | Current evaluation and policy-comparison rules |
+| `docs/runbooks/PIPELINE_RECREATION.md` | Historical/reproducible artifact paths with a current-path notice |
+| `docs/PRODUCTION_READINESS.md`, `docs/DESIGN_REVIEW.md`, historical reports | Historical snapshots and supporting evidence, not active direction |
+
+## Phase Sequence
+
+| Phase | Purpose | Verified status/evidence | Exit condition and why next |
+| --- | --- | --- | --- |
+| A | Register Set 1 source identity | Complete: `311fb72`; `data/manifests/ims_set1/v1/recordings_manifest.jsonl` | Immutable source identity enabled canonical identities. |
+| B | Build Set 1 physical identities | Complete: `597a543`; `data/canonical/ims_set1/v1/canonicalization_summary.json` | Physical recording, bearing, and sensor identities were pinned. |
+| C | Record Set 1 terminal-outcome evidence | Complete: `41babf5`; `data/canonical/ims_set1_outcomes/v1/` | Endpoint proxy evidence was separated from true event-time claims. |
+| D | Publish sensor-local base features | Complete: `2a9030c`; `data/canonical/ims_set1_sensor_local_base_features/v1/` | Target-independent canonical features are available. |
+| E | Test Set 1 endpoint-proxy identifiability | Complete: `8f2520c`; `reports/evaluation/ims_set1_phase_e_identifiability_v1/` | Shared clock exactly explains the proxy; it cannot establish degradation. |
+| F | Register local Set 2 and observed-candidate packages | Complete: `193af30`; `data/manifests/ims_sets23_source_packages/v1/` | Package identity was recorded without signal interpretation. |
+| G | Establish structural identities | Complete: `64dda9e`; `data/manifests/ims_sets23_structural_identity/v3/` | Structural validity is known; observed-candidate publisher identity remains unresolved. |
+| H | Record mapping evidence | Complete: `64d0f0c`; `data/manifests/ims_sets23_mapping_evidence/v1/` | Set 2 channel mapping is documented; candidate mapping remains unresolved. |
+| I | Freeze dataset roles | Complete: `6197324`; `data/manifests/ims_sets23_role_freeze/v1/` | Roles preserve prior metadata awareness without authorizing use. |
+| J | Adjudicate Set 2 terminal metadata | Complete: `e7cd06`; `data/manifests/ims_set2_outcome_evidence/v1/` | No supervised Set 2 target is justified from available metadata. |
+| K | Search for authoritative Set 2 event evidence | Complete: `34dfc08`; `data/manifests/ims_set2_event_evidence/v1/` | No bearing-linked event time or interval was found; target creation remains prohibited. |
+| L | Freeze condition-monitoring direction | Current documentation contract | Integrate this contract before any implementation of the monitor. |
+| M | Implement Set 1 causal condition monitor | Planned, separately authorized | Demonstrate causal scoring and human-review states without target leakage. |
+| N | Compare policies and scenario costs | Planned, separately authorized | Compare predeclared policies with explicit assumptions and ranges. |
+| O | Perform frozen external validation | Planned, separately authorized | Consider Set 2 first; consider the observed candidate only after source/identity resolution. |
+| P | Build production engineering controls | Planned, separately authorized | Require streaming feature parity, versioned inference, monitoring, rollback, and human-review workflow. |
+| Q | Define prospective validation and client data contract | Planned, separately authorized | Obtain operational truth, costs, and decision ownership. |
+| R | Run field pilot, calibrate, and seek deployment signoff | Planned, separately authorized | Require field evidence before any deployment decision. |
+
+The high-impact sequence is **L -> M -> N -> O**. Serving work follows only after
+evidence supports it; it is not an outcome of this documentation phase.
+
+## Non-Negotiable Evaluation Boundary
+
+- Thousands of recordings are repeated observations, not independent failures.
+- Selection must group by physical trajectory and use chronological or purged
+  evaluation with fold-local preprocessing. Random row splits are not permitted.
+- Set 1 has two documented terminal failures. This limitation is irreducible:
+  use simple interpretable methods, trajectory-level reporting, sensitivity
+  analysis, explicit uncertainty, and later frozen external validation.
+- Elapsed-time-only and fixed-interval policies are mandatory baselines. A signal
+  model must outperform them under trajectory-safe evaluation before it is said
+  to add condition-monitoring value. Learning experiment age alone is not enough.
+- Business value is scenario/backtest evidence only. Dollar claims require explicit
+  client inputs and later prospective field evidence.

--- a/docs/SET2_INTAKE_DESIGN.md
+++ b/docs/SET2_INTAKE_DESIGN.md
@@ -1,6 +1,6 @@
 # Set 2 Intake Architecture and Terra Handoff Plan
 
-**Status:** Historical intake architecture. Phase I freezes `ims_set2` as
+**Current status -- historical design only:** Phase I freezes `ims_set2` as
 `development_evidence` with prior terminal metadata awareness; it remains unusable until a
 separately authorized use. Phase J adjudicates terminal metadata only: bearing 1 has documented
 terminal damage with timing unknown, while bearings 2-4 have no reported bearing-specific
@@ -8,7 +8,8 @@ terminal outcome and no established terminal event. It concludes no supervised t
 created from available metadata. It is not an untouched or blind external holdout. Historical
 sections below that describe an exact failure/RUL-zero endpoint,
 censoring, or an external-validation role are superseded as current assumptions and retained
-only as historical design context.
+only as historical design context. D-043 and `docs/PROJECT_ROADMAP.md` are the active
+direction; this document does not authorize Set 2 targets, development use, or evaluation.
 
 **Phase K update:** A finite primary and secondary documentation search found no authoritative
 bearing-linked event timestamp or independently supported interval bounds. Repeated claims that
@@ -246,8 +247,8 @@ local hash and byte size, and a metadata-only archive index in
 `data/manifests/ims_sets23_source_packages/v1/`. This is source registration, not Set 2
 consumption. No archive member was extracted for this registration, no signal payload was
 parsed, and no Set 2 identity, outcome, feature, split, evaluation, model, or serving
-artifact exists. The package remains a conditional development-evidence candidate only;
-the external-before-pooling rule remains in force.
+artifact exists. At that historical Phase F point, the package remained a conditional
+development-evidence candidate and the external-before-pooling rule was proposed.
 
 ### 5.2 Permitted integrity checks and consumption boundary
 
@@ -262,7 +263,8 @@ a persisted derived artifact, or supplies Set 2 observations to any feature, fit
 scoring, drift, or evaluation operation. At that first consumption point, the run must
 record the archive hash, manifest version, config hash, code revision, command, and
 output artifact identifier. A checksum or member-list inspection alone does not consume
-Set 2. Set 2 remains external-validation data before any pooling decision.
+Set 2. The historical proposal treated Set 2 as external-validation data before any
+pooling decision; Phase I's frozen development-evidence role is the current truth.
 
 ### 5.3 Transactional extraction
 

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -927,6 +927,67 @@ separate acceptance decision.
 
 ---
 
+### D-043 — Freeze causal condition-monitoring direction before new modeling
+**Decision:** The primary product objective is causal condition-deviation monitoring
+that emits persistent inspection alerts for human review. It supports maintenance
+decisions and does not automatically command replacement. For a trajectory whose
+official IMS manual identifies terminal damage, the final observation timestamp may
+be used only as the documented modeling convention
+`observed_failure_endpoint_proxy`. This supports secondary retrospective time-to-
+observed-endpoint benchmarks; it is not exact failure onset, a last-good/first-bad
+record, functional-failure threshold, or field maintenance truth.
+
+**Why:** Phase E proved that the Set 1 observed-run-end proxy is exactly explained by
+the shared experiment clock, so learning elapsed experiment age is not evidence of
+bearing condition. Phases J and K found no authoritative Set 2 bearing-linked event
+time or interval, so no supervised Set 2 target is authorized. Set 1 has only two
+documented terminal failures, which remains an irreducible statistical limitation.
+
+**Required next implementation contract:** Fit an early-prefix, robust sensor-local
+baseline and reference behavior for each monitored trajectory; score later timestamps
+causally without future information or full-trajectory normalization; aggregate the
+two sensor views with fixed documented weights at the physical-bearing timestamp;
+then apply causal change detection and persistence/hysteresis. The only scientific
+states are `baseline-consistent`, `deviation-observed`,
+`persistent-severe-deviation`, and `insufficient-evidence`. These are deviation
+regimes, not healthy, warning, failure, maintenance, or RUL truth. Endpoint proximity
+may be used only after scoring for retrospective evaluation, never for feature fitting,
+threshold fitting, or online scoring. A small sensitivity grid for baseline-prefix
+length, reference neighbors, threshold, persistence, and sensor weighting must be
+predeclared.
+
+**Evaluation and business boundary:** Physical trajectories, rather than rows or
+sensor views, are the unit of grouping. Use chronological or purged evaluation with
+fold-local preprocessing. Elapsed-time-only and fixed-interval policies are mandatory
+baselines, and a signal monitor must outperform them before claiming
+condition-monitoring value. Report baseline stability, descriptive trendability and
+monotonicity, cross-bearing consistency, alert burden, persistence/hysteresis, lead
+time to the observed endpoint, abstention, and sensitivity. Alert burden is not a
+false-positive rate without supported state truth, and observed-endpoint lead time is
+not failure lead time. Later policy work must compare run to failure, fixed-interval
+replacement, elapsed-time-only, endpoint-proxy supervised benchmark, and signal-based
+condition monitor using explicit client inputs for downtime, replacement, inspection,
+intervention lead time, lost remaining life, and operating horizon/population. Until
+prospective client evidence exists, report ranges and sensitivity only, never
+guaranteed savings, production effectiveness, exact failure timing, or automatic
+replacement readiness.
+
+**Dataset boundary:** Set 1 is development evidence. Set 2 retains its frozen Phase I
+role and is not authorized for use by this decision; the observed candidate remains
+protected until source and identity resolution. Any later external validation, client
+data contract, field pilot, or serving work needs separate authorization and evidence.
+
+**Rejected alternatives:** RUL-first retuning, random row-split selection,
+age-only evidence, automatic replacement, and immediate Set 2 target/model work are
+rejected because they conflict with the established leakage, identifiability, role,
+and event-evidence boundaries.
+
+**Supersession:** This is the active direction for roadmap, architecture, and
+evaluation guidance. It supersedes conflicting active RUL-first or retune-next
+instructions without rewriting historical decisions, audits, reports, or prototypes.
+
+---
+
 ## Log format for future entries
 
 ```

--- a/docs/runbooks/PIPELINE_RECREATION.md
+++ b/docs/runbooks/PIPELINE_RECREATION.md
@@ -1,5 +1,12 @@
 # Runbook — Recreating the production database from empty
 
+> **Current-path notice:** This runbook preserves reproducible historical evidence paths.
+> The active direction is `docs/PROJECT_ROADMAP.md`,
+> `docs/CONDITION_MONITORING_ARCHITECTURE.md`, and D-043. Phase L freezes the
+> condition-monitoring contract only; no causal monitor, policy comparison, or serving
+> workflow is implemented here. Historical pipeline instructions below do not authorize
+> a new RUL-first model, Set 2 target, or production claim.
+
 **Status as of 2026-07-04:** Postgres is healthy but empty (no `features` table →
 migrations have never been applied). This runbook documents how the canonical
 pipeline is *intended* to build the database, verified by reading every script, and


### PR DESCRIPTION
## Scope

Documentation-only Phase L contract. It freezes causal condition-deviation monitoring with persistent human-review inspection alerts as the next direction before any new modeling.

- `observed_failure_endpoint_proxy` is a secondary retrospective convention, not exact failure onset, RUL truth, or automatic replacement authority.
- Elapsed-time-only and fixed-interval policies are mandatory baselines; trajectory-safe evaluation and fold-local preprocessing are required.
- Set 1 remains limited development evidence. Set 2 retains its frozen governance and no target/use authorization. The observed candidate remains protected pending source and identity resolution.
- The roadmap sequence is L -> M -> N -> O; serving follows only after evidence.

This change adds the active roadmap and architecture, D-043, and clear historical-snapshot notices. It contains no data, model, feature, target, serving, or generated-report changes.
